### PR TITLE
Remove PropTypes warning

### DIFF
--- a/components/Timeline.js
+++ b/components/Timeline.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import s from './styles'
 
 class Timeline extends Component {
@@ -17,7 +18,7 @@ class Timeline extends Component {
 }
 
 Timeline.propTypes = {
-  children: React.PropTypes.node.isRequired
+  children: PropTypes.node.isRequired
 }
 
 export default Timeline

--- a/components/TimelineEvent.js
+++ b/components/TimelineEvent.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import s from './styles'
 
 class TimelineEvent extends Component {
@@ -54,15 +55,15 @@ class TimelineEvent extends Component {
 }
 
 TimelineEvent.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  title: React.PropTypes.node.isRequired,
-  createdAt: React.PropTypes.node.isRequired,
-  buttons: React.PropTypes.node,
-  container: React.PropTypes.string,
-  icon: React.PropTypes.node,
-  iconColor: React.PropTypes.string,
-  contentStyle: React.PropTypes.object,
-  style: React.PropTypes.object
+  children: PropTypes.node.isRequired,
+  title: PropTypes.node.isRequired,
+  createdAt: PropTypes.node.isRequired,
+  buttons: PropTypes.node,
+  container: PropTypes.string,
+  icon: PropTypes.node,
+  iconColor: PropTypes.string,
+  contentStyle: PropTypes.object,
+  style: PropTypes.object
 }
 
 export default TimelineEvent

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "invariant": "^2.0.0",
+    "prop-types": "^15.5.10",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },


### PR DESCRIPTION
This PR removes warning "Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead." which comes when using PropTypes directly from React.

Please kindly merge that change and update npm package.