### PR TITLE
Proper event container style overwrite

### DIFF
--- a/components/TimelineEvent.js
+++ b/components/TimelineEvent.js
@@ -26,7 +26,7 @@ class TimelineEvent extends Component {
   containerStyle() {
     const {style} = this.props
     const containerStyle = {...s.eventContainer, ...style}
-    return this.showAsCard() ? {...containerStyle, ...s.card} : containerStyle
+    return this.showAsCard() ? {...s.card, ...containerStyle} : containerStyle
   }
 
   render() {


### PR DESCRIPTION
with this change your example [here](https://rcdexta.github.io/react-event-timeline/?selectedKind=Timeline&selectedStory=Card%20Appearance&full=0&down=0&left=1&panelRight=0) will work