### PR TITLE
remove invalid paths from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "react-event-timeline",
   "description": "A responsive event timeline in React.js",
   "main": "dist/index.js",
-  "jsnext:main": "components/index.js",
-  "module": "components/index.js",
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
Hello! Thanks for this component.
My Parcel app crashes because of these two properties in the package.json:
```
...
  "jsnext:main": "components/index.js",
  "module": "components/index.js",
...
```
https://github.com/rcdexta/react-event-timeline/blob/master/package.json#L5-L6

Looks like you don't do bundles other than dist/index.js, so I would remove them.